### PR TITLE
Access DOM node directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ var Flickity = React.createClass ({
   },
 
   componentDidMount: function () {
-    var carousel = this.refs.carousel.getDOMNode()
+    var carousel = this.refs.carousel
     this.flkty = new myFlickity(carousel, this.props.options)
     this.flkty.on('cellSelect', this.updateSelected)
   },


### PR DESCRIPTION
Fixes `Warning: ReactDOMComponent: Do not access .getDOMNode() of a DOM node; instead, use the node directly.`
